### PR TITLE
FoW - 'Support from foggy coastal territroy'-options fix

### DIFF
--- a/variants/ClassicFog/resources/supportfog.js
+++ b/variants/ClassicFog/resources/supportfog.js
@@ -12,6 +12,46 @@ function SupportFog() {
 					return false;
 				else 
 					return true;
+			},
+			
+			
+			/*
+			 * Modified this method to use Borders instead of CoastalBorders if countryID = 0.
+			 * 
+			 * 
+			 * If there is a (fake) unit in a foggy territory with several coasts, 
+			 * Borders shoul be used instead of CoastalBorders as there could be 
+			 * a fleet on one of the coasts or an army on the main territory and
+			 * CoastalBorders does only include the real borders for the current
+			 * subterritory.
+			 * 
+			 * For real units CoastalBorders still needs to be used to avoid
+			 * non-movable options from opposite coasts.
+			 */
+			getMovableTerritories: function () {
+
+				if (Object.isUndefined(this.getMovableTerritoriesCache)){
+					if(this.countryID == 0)
+						this.getMovableTerritoriesCache = this.Territory.Borders
+								.select(this.canCrossBorder, this).pluck('id').compact()
+								.map(function (n) {
+									return Territories.get(n);
+								}, this)
+								.sort(function (a, b) {
+									return a.name > b.name;
+								});
+					else
+						this.getMovableTerritoriesCache = this.Territory.CoastalBorders
+								.select(this.canCrossBorder, this).pluck('id').compact()
+								.map(function (n) {
+									return Territories.get(n);
+								}, this)
+								.sort(function (a, b) {
+									return a.name > b.name;
+								});
+				}
+
+				return this.getMovableTerritoriesCache;
 			}
 		
 		});

--- a/variants/ClassicFog/variant.php
+++ b/variants/ClassicFog/variant.php
@@ -34,6 +34,7 @@
 	1.0.12: countries no longer sorted by value...
 	1.0.13: do not hide the county-value for CDed countries, so new players can join...
 	1.0.15: shuffle the occupationbar on the homescreen to hide the strongest nation.
+	1.0.16: Fixed supportMove option from foggy multi-coast territory
 
 */
 
@@ -47,7 +48,7 @@ class ClassicFogVariant extends WDVariant {
 	public $description= 'This is the classic map, but players can only see a limited part of the map';
 	public $adapter    = 'Oliver Auth';
 	public $version    = '1.0';
-	public $codeVersion= '1.0.15';
+	public $codeVersion= '1.0.16';
 
 	public $countries=array('England', 'France', 'Italy', 'Germany', 'Austria', 'Turkey', 'Russia');
 	

--- a/variants/RatWars/resources/supportfog.js
+++ b/variants/RatWars/resources/supportfog.js
@@ -12,6 +12,46 @@ function SupportFog() {
 					return false;
 				else 
 					return true;
+			},
+			
+			
+			/*
+			 * Modified this method to use Borders instead of CoastalBorders if countryID = 0.
+			 * 
+			 * 
+			 * If there is a (fake) unit in a foggy territory with several coasts, 
+			 * Borders shoul be used instead of CoastalBorders as there could be 
+			 * a fleet on one of the coasts or an army on the main territory and
+			 * CoastalBorders does only include the real borders for the current
+			 * subterritory.
+			 * 
+			 * For real units CoastalBorders still needs to be used to avoid
+			 * non-movable options from opposite coasts.
+			 */
+			getMovableTerritories: function () {
+
+				if (Object.isUndefined(this.getMovableTerritoriesCache)){
+					if(this.countryID == 0)
+						this.getMovableTerritoriesCache = this.Territory.Borders
+								.select(this.canCrossBorder, this).pluck('id').compact()
+								.map(function (n) {
+									return Territories.get(n);
+								}, this)
+								.sort(function (a, b) {
+									return a.name > b.name;
+								});
+					else
+						this.getMovableTerritoriesCache = this.Territory.CoastalBorders
+								.select(this.canCrossBorder, this).pluck('id').compact()
+								.map(function (n) {
+									return Territories.get(n);
+								}, this)
+								.sort(function (a, b) {
+									return a.name > b.name;
+								});
+				}
+
+				return this.getMovableTerritoriesCache;
 			}
 		
 		});

--- a/variants/RatWars/variant.php
+++ b/variants/RatWars/variant.php
@@ -22,6 +22,7 @@
 	Changelog:
 	1.0:     initial release
 	1.1  : only one class in ProcessGame to avoid problems with the banPlayer or uncrashGames code
+	1.1.1: Fixed supportMove option from foggy multi-coast territory
 */
 
 defined('IN_CODE') or die('This script can not be run by itself.');
@@ -35,7 +36,7 @@ class RatWarsVariant extends WDVariant {
 	public $author     ='kaner406';
 	public $adapter    ='kaner406 / Oliver Auth';
 	public $version    ='1';
-	public $codeVersion='1.1';	
+	public $codeVersion='1.1.1';	
 	
 	public $countries=array('Dead Rabbits','Plug Uglies','Shirt Tails','Hell-Cats');	
 

--- a/variants/TenSixtySix/resources/supportfog.js
+++ b/variants/TenSixtySix/resources/supportfog.js
@@ -12,6 +12,46 @@ function SupportFog() {
 					return false;
 				else 
 					return true;
+			},
+			
+			
+			/*
+			 * Modified this method to use Borders instead of CoastalBorders if countryID = 0.
+			 * 
+			 * 
+			 * If there is a (fake) unit in a foggy territory with several coasts, 
+			 * Borders shoul be used instead of CoastalBorders as there could be 
+			 * a fleet on one of the coasts or an army on the main territory and
+			 * CoastalBorders does only include the real borders for the current
+			 * subterritory.
+			 * 
+			 * For real units CoastalBorders still needs to be used to avoid
+			 * non-movable options from opposite coasts.
+			 */
+			getMovableTerritories: function () {
+
+				if (Object.isUndefined(this.getMovableTerritoriesCache)){
+					if(this.countryID == 0)
+						this.getMovableTerritoriesCache = this.Territory.Borders
+								.select(this.canCrossBorder, this).pluck('id').compact()
+								.map(function (n) {
+									return Territories.get(n);
+								}, this)
+								.sort(function (a, b) {
+									return a.name > b.name;
+								});
+					else
+						this.getMovableTerritoriesCache = this.Territory.CoastalBorders
+								.select(this.canCrossBorder, this).pluck('id').compact()
+								.map(function (n) {
+									return Territories.get(n);
+								}, this)
+								.sort(function (a, b) {
+									return a.name > b.name;
+								});
+				}
+
+				return this.getMovableTerritoriesCache;
 			}
 		
 		});

--- a/variants/TenSixtySix/variant.php
+++ b/variants/TenSixtySix/variant.php
@@ -34,6 +34,7 @@
 	1.1.3: Memberlist now sorted by alphabet and not by value
 	1.1.4:  small improvements, so the map work with the edit-tool
 	1.2  : only one class in ProcessGame to avoid problems with the banPlayer or uncrashGames code
+	1.2.1: Fixed supportMove option from foggy multi-coast territory
 
 */
 
@@ -48,7 +49,7 @@ class TenSixtySixVariant extends WDVariant {
 	public $author     = 'Gavin Atkinson (The Ambassador) and Emmanuele Ravaioli (Tadar Es Darden)';
 	public $adapter    = 'Gavin Atkinson / Emmanuele Ravaioli / Oliver Auth';
 	public $version    = '1';
-	public $codeversion= '1.2';
+	public $codeversion= '1.2.1';
 
 	public $countries=array('English', 'Normans', 'Norwegians');
 

--- a/variants/TenSixtySix_V2/variant.php
+++ b/variants/TenSixtySix_V2/variant.php
@@ -21,6 +21,7 @@
 
 	Changelog:
 	2.0: initial release
+	2.1.1: Fixed supportMove option from foggy multi-coast territory
 
 */
 
@@ -32,7 +33,7 @@ class TenSixtySix_V2Variant extends TenSixtySixVariant {
 	public $name       = 'TenSixtySix_V2';
 	public $fullName   = '1066 (V2.0)';
 	public $version    = '2.0';
-	public $codeversion= '2.1';
+	public $codeversion= '2.1.1';
 
 	public function __construct() {
 		parent::__construct();

--- a/variants/TenSixtySix_V3/variant.php
+++ b/variants/TenSixtySix_V3/variant.php
@@ -1,5 +1,10 @@
 <?php
 
+/*
+ * Changelog:
+ * 	1.3.1: Fixed supportMove option from foggy multi-coast territory
+ */
+
 defined('IN_CODE') or die('This script can not be run by itself.');
 
 class TenSixtySix_V3Variant extends TenSixtySixVariant {
@@ -8,7 +13,7 @@ class TenSixtySix_V3Variant extends TenSixtySixVariant {
 	public $name       = 'TenSixtySix_V3';
 	public $fullName   = '1066 (V3.0)';
 	public $version    = '3';
-	public $codeVersion= '1.3';
+	public $codeVersion= '1.3.1';
 
 	public function __construct() {
 		parent::__construct();


### PR DESCRIPTION
Fixes the lack of option to support a move to a sea province from a foggy territory with several coasts.