### PR TITLE
Fix for Europa Renovatio regularly crashing

### DIFF
--- a/variants/Europa_Renovatio/classes/processOrderBuilds.php
+++ b/variants/Europa_Renovatio/classes/processOrderBuilds.php
@@ -57,6 +57,58 @@ class BuildAnywhere_processOrderBuilds extends processOrderBuilds
 		}
 	}
 	
+	/** 
+	 * This extension replaces the algorithm to decide which units to destroy if 
+	 * valid destroy orders were missing. 
+	 * Originally the unit destroy index is used to determine which unit is 
+	 * furthest away from home SCs. Since there are no real home SCs in Build 
+	 * Anywhere variants and it is also possible to get units into spots that 
+	 * are not reachable from the original home SCs the algorithm is replaced by
+	 * a simpler one that just randomly chooses to destroy units not currently 
+	 * capturing a SC.
+	 */
+	public function apply()
+	{
+		global $Game, $DB;
+
+		$DB->sql_put(
+				"DELETE FROM u
+				USING wD_Units AS u
+				INNER JOIN wD_Orders AS o ON ( ".$Game->Variant->deCoastCompare('o.toTerrID','u.terrID')." AND u.gameID = o.gameID )
+				INNER JOIN wD_Moves m ON ( m.orderID = o.id AND m.gameID=".$GLOBALS['GAMEID']." )
+				WHERE o.gameID = ".$Game->id." AND o.type = 'Destroy'
+					AND m.success='Yes'");
+
+		// Remove units randomly from non-SCs for any destroy orders that weren't successful
+		$tabl = $DB->sql_tabl(
+					"SELECT o.id, o.countryID FROM wD_Orders o
+					INNER JOIN wD_Moves m ON ( m.orderID = o.id AND m.gameID=".$GLOBALS['GAMEID']." )
+					WHERE o.type = 'Destroy' AND m.success = 'No' AND o.gameID = ".$Game->id
+				);
+		while(list($orderID, $countryID) = $DB->tabl_row($tabl))
+		{
+			list($unitID, $terrID) = $DB->sql_row(
+				"SELECT u.id, u.terrID FROM wD_Units u
+					INNER JOIN wD_Territories t
+						ON ".$Game->Variant->deCoastCompare('t.id','u.terrID')."
+				WHERE u.gameID = ".$Game->id." AND u.countryID = ".$countryID."
+					AND t.mapID=".$Game->Variant->mapID." AND t.supply = 'No'
+				ORDER BY RAND() LIMIT 1");
+
+			$DB->sql_put("UPDATE wD_Orders SET toTerrID = '".$terrID."' WHERE id = ".$orderID);
+			$DB->sql_put("UPDATE wD_Moves
+				SET success = 'Yes', toTerrID = ".$Game->Variant->deCoast($terrID)." WHERE gameID=".$GLOBALS['GAMEID']." AND orderID = ".$orderID);
+
+			$DB->sql_put("DELETE FROM wD_Units WHERE id = ".$unitID);
+		}
+
+		$DB->sql_put("INSERT INTO wD_Units ( gameID, countryID, type, terrID )
+					SELECT o.gameID, o.countryID, IF(o.type = 'Build Army','Army','Fleet') as type, o.toTerrID
+					FROM wD_Orders o INNER JOIN wD_Moves m ON ( m.orderID = o.id AND m.gameID=".$GLOBALS['GAMEID']." )
+					WHERE o.gameID=".$Game->id." AND o.type LIKE 'Build%' AND m.success = 'Yes'");
+		// All players have the correct amount of units
+	}
+	
 }
 
 class CustomStart_processOrderBuilds extends BuildAnywhere_processOrderBuilds

--- a/variants/Europa_Renovatio/variant.php
+++ b/variants/Europa_Renovatio/variant.php
@@ -16,6 +16,11 @@
 
 	You should have received a copy of the GNU Affero General Public License
 	along with webDiplomacy. If not, see <http://www.gnu.org/licenses/>.
+ 
+	---
+	
+	Changelog:
+	1.1:	Bug with Build Anywhere variants using the unit destroy index fixed
 	
 */
 
@@ -34,7 +39,7 @@ class Europa_RenovatioVariant extends WDVariant {
 	public $author     = 'Technostar';
 	public $adapter    = 'Technostar';
 	public $version    = '1';
-	public $codeVersion= '1.0.4';
+	public $codeVersion= '1.1';
 	
 	public $countries=array('Aragon','Austria','Bavaria','Bohemia','Brandenburg','Burgundy','Castille','Denmark','England','France','Genoa','Great-Horde','Hungary','Lithuania','Livonian-Order','Mamluks','Milan','Morocco','Muscovy','Naples','Norway','Novgorod','Ottomans','Papacy','Poland','Portugal','Qara-Qoyunlu','Savoy','Saxony','Scotland','Sweden','Switzerland','Teutonic-Order','Tlemcen','Tunis','Venice');
 	public function __construct() {


### PR DESCRIPTION
This fix replaces the algorithm to automatically choose units to destroy with the unit destroy index by an algorithm that just chooses units randomly that are not capturing an SC. This should resolve the issue of Europa Renovatio games regularly crashing.

If this small code change proved to be working, it should be copied to all other Build Anywhere variants.