### PR TITLE
Various fixes

### DIFF
--- a/global/definitions.php
+++ b/global/definitions.php
@@ -47,7 +47,7 @@ define("JSDIR", 'javascript');
 define("CSSDIR", 'css');
 
 //Increment these versions whenever you update any js or css files for cachebusting
-define("JSVERSION",1.41);
+define("JSVERSION",1.42);
 define("CSSVERSION",1.37);
 
 if( !defined('FACEBOOK') )

--- a/variants/ClassicChaoctopi/variant.php
+++ b/variants/ClassicChaoctopi/variant.php
@@ -21,6 +21,7 @@
 	
 	Changelog:
 	1.0:   initial release based on the Chaos variant 1.7 and the Octopus variant 1.0.1 (by Emmanuele)
+	1.0.2: Fix for panelMembersHome memberslist
 	
 */
 
@@ -35,7 +36,7 @@ class ClassicChaoctopiVariant extends WDVariant {
 	public $author     ='kaner406';
 	public $adapter    ='Emmanuele Ravaioli / Carey Jensen / Oliver Auth';
 	public $version    ='1.0.1';
-	public $codeVersion='1.0.1';
+	public $codeVersion='1.0.2';
 
 	public $countries=array(
 		'Ankara'       , 'Belgium', 'Berlin'  , 'Brest'    , 'Budapest', 'Bulgaria'  , 'Constantinople', 'Denmark', 'Edinburgh',

--- a/variants/GobbleEarth/classes/processOrderBuilds.php
+++ b/variants/GobbleEarth/classes/processOrderBuilds.php
@@ -3,48 +3,6 @@
 defined('IN_CODE') or die('This script can not be run by itself.');
 
 class GobbleEarthVariant_processOrderBuilds extends processOrderBuilds {
-
-	public function archiveMoves()
-	{
-		global $DB, $Game;
-		
-		parent::archiveMoves();
-		
-		// Add Wait-orders in the database too...
-		$DB->sql_put(
-			"INSERT INTO wD_MovesArchive (
-				gameID, turn, type, terrID, /* Index */
-				countryID, toTerrID, fromTerrID, viaConvoy, /* Order */
-				unitType, /* Unit */
-				success, dislodged /* Move */
-			)
-			SELECT
-				o.gameID, ".$Game->turn.", o.type, NULL,
-				o.countryID, NULL, NULL, 'No',
-				NULL,
-				'Yes', 'Yes'
-			FROM wD_Orders o
-			INNER JOIN wD_Moves m ON ( m.orderID = o.id AND m.gameID=".$GLOBALS['GAMEID']." )
-			WHERE o.gameID = ".$Game->id." AND o.type = 'Wait'");
-			
-			$DB->sql_put(
-				"INSERT INTO wD_MovesArchive (
-					gameID, turn, type, terrID, /* Index */
-					countryID, toTerrID, fromTerrID, viaConvoy, /* Order */
-					unitType, /* Unit */
-					success, dislodged /* Move */
-				)
-				SELECT
-					o.gameID, ".$Game->turn.", o.type, o.toTerrID,
-					o.countryID, NULL, NULL, 'No',
-					NULL,
-					m.success, 'No'
-				FROM wD_Orders o
-				/* Moves needed to get success/dislodged results data */
-				INNER JOIN wD_Moves m ON ( m.orderID = o.id AND m.gameID=".$GLOBALS['GAMEID']." )
-				WHERE o.gameID = ".$Game->id." AND NOT o.type = 'Wait' AND success = 'No'");
-
-	}
 	
 	public function create()
 	{

--- a/variants/GobbleEarth/resources/renameSCsV2.js
+++ b/variants/GobbleEarth/resources/renameSCsV2.js
@@ -9,13 +9,13 @@ Array.prototype.inArray = function (value)	{
 };	
 
 function RenameSCs(homeSCs) {
-	if (ordersData[0].type != "Destroy")
+	if (ordersData.length > 0 && ordersData[0].type != "Destroy")
 	{
 		Territories.each(function(p){
 			var t=p[1];
 			if( !homeSCs.inArray(t.coastParent.name ))
 			{
-				t.coastParent.name = t.coastParent.name + " (colonial build)";
+				t.name = t.name + " (colonial build)";
 			}
 		},this);
 	}

--- a/variants/GobbleEarth/variant.php
+++ b/variants/GobbleEarth/variant.php
@@ -1,5 +1,9 @@
 <?php
 
+/*
+ * 1.2.3:	Fixes of Colonial builds after code base updates
+ */
+
 defined('IN_CODE') or die('This script can not be run by itself.');
 
 class GobbleEarthVariant extends WDVariant {
@@ -11,7 +15,7 @@ class GobbleEarthVariant extends WDVariant {
 	public $author     = 'Christian Günther-Hanssen';
 	public $adapter    = 'The same aided by Oliver Auth';
 	public $version    = '1';
-	public $codeVersion= '1.2.2';
+	public $codeVersion= '1.2.3';
 
 	public $countries=array('Austria','England','France','Germany','Italy','Russia','Turkey','China','Japan','Brazil','Argentina','Colombia','Mexico','USA');
 


### PR DESCRIPTION
Some fixes for some minor issues:

- Chaoctopi: Now works correctly by using the same member list code as other many-member variants (initial code heavily depended on HTML output that was changed with recent webdip update)
- GobbleEarth: Fix after the general change from 2018 to store all 'Wait'-orders broke the Colonial builds; also some minor fix for the interface to display Colonial Builds on Coast correctly and to not through an error when no build orders
- Interactive Map: Occasional incorrect territory grey-out on initial map fixed
