### PR TITLE
BUGFIX: RSS Feed

### DIFF
--- a/rss.php
+++ b/rss.php
@@ -49,7 +49,6 @@ $tabl=$DB->sql_tabl('SELECT type, text, linkName, linkID, timeSent FROM wD_Notic
 	WHERE toUserID = "'.$userID.'" AND substring(linkName,1,3) <> "To:"
 	ORDER BY timeSent DESC LIMIT 50');
 	
-$index = 0;
 while(list($type, $text, $linkName, $linkID, $timeSent) = $DB->tabl_row($tabl))
 {
 	if ($type == 'Game')
@@ -64,11 +63,10 @@ while(list($type, $text, $linkName, $linkID, $timeSent) = $DB->tabl_row($tabl))
 	$rssfeed .= "    <item>\n";
 	$rssfeed .= "      <title>".$linkName."</title>\n";
 	$rssfeed .= "      <description>".$text."</description>\n";
-	$rssfeed .= "      <guid>".$link."time".$timeSent."index".$index."</guid>\n";
+	$rssfeed .= "      <guid>".$link."time".$timeSent."</guid>\n";
 	$rssfeed .= "      <link>".$link."</link>\n";
 	$rssfeed .= "      <pubDate>".date("D, d M Y H:i:s O", $timeSent)."</pubDate>\n";
 	$rssfeed .= "    </item>\n";
-	$index++;
 }
  
 $rssfeed .= "  </channel>\n";

--- a/rss.php
+++ b/rss.php
@@ -38,12 +38,12 @@ list($userID, $name)= $DB->sql_row('SELECT id, username FROM wD_Users WHERE rssI
 $rssLink = "http://".str_replace("rss.php","",$_SERVER['SERVER_NAME'].$_SERVER['PHP_SELF']);
 $rssfeed = "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\n";
 $rssfeed .= "<rss version=\"2.0\">\n";
-$rssfeed .= "<channel>\n";
-$rssfeed .= "<title>".$name."'s VDiplomacy RSS feed</title>\n";
-$rssfeed .= "<link>http://".$_SERVER['SERVER_NAME']."</link>\n";
-$rssfeed .= "<description>This is the personal vDip RSS-feed of ".$name.".</description>\n";
-$rssfeed .= "<language>en-us</language>\n";
-$rssfeed .= "<copyright>Copyright (C) 2018 vDiplomacy.com</copyright>\n";
+$rssfeed .= "  <channel>\n";
+$rssfeed .= "    <title>".$name."'s VDiplomacy RSS feed</title>\n";
+$rssfeed .= "    <link>http://".$_SERVER['SERVER_NAME']."</link>\n";
+$rssfeed .= "    <description>This is the personal vDip RSS-feed of ".$name.".</description>\n";
+$rssfeed .= "    <language>en-us</language>\n";
+$rssfeed .= "    <copyright>Copyright (C) 2018 vDiplomacy.com</copyright>\n";
  
 $tabl=$DB->sql_tabl('SELECT type, text, linkName, linkID, timeSent FROM wD_Notices
 	WHERE toUserID = "'.$userID.'" AND substring(linkName,1,3) <> "To:"
@@ -61,17 +61,17 @@ while(list($type, $text, $linkName, $linkID, $timeSent) = $DB->tabl_row($tabl))
 	$text = strip_tags ($text);
 	$text = str_replace("&","-",$text);
 	
-	$rssfeed .= "<item>\n";
-	$rssfeed .= "<title>".$linkName."</title>\n";
-	$rssfeed .= "<description>".$text."</description>\n";
-	$rssfeed .= "<guid>".$link."time".$timeSent."index".$index."</guid>\n";
-	$rssfeed .= "<link>".$link."</link>\n";
-	$rssfeed .= "<pubDate>".date("D, d M Y H:i:s O", $timeSent)."</pubDate>\n";
-	$rssfeed .= "</item>\n";
+	$rssfeed .= "    <item>\n";
+	$rssfeed .= "      <title>".$linkName."</title>\n";
+	$rssfeed .= "      <description>".$text."</description>\n";
+	$rssfeed .= "      <guid>".$link."time".$timeSent."index".$index."</guid>\n";
+	$rssfeed .= "      <link>".$link."</link>\n";
+	$rssfeed .= "      <pubDate>".date("D, d M Y H:i:s O", $timeSent)."</pubDate>\n";
+	$rssfeed .= "    </item>\n";
 	$index++;
 }
  
-$rssfeed .= "</channel>\n";
+$rssfeed .= "  </channel>\n";
 $rssfeed .= "</rss>\n";
 
 echo $rssfeed;

--- a/rss.php
+++ b/rss.php
@@ -49,6 +49,7 @@ $tabl=$DB->sql_tabl('SELECT type, text, linkName, linkID, timeSent FROM wD_Notic
 	WHERE toUserID = "'.$userID.'" AND substring(linkName,1,3) <> "To:"
 	ORDER BY timeSent DESC LIMIT 50');
 	
+$index = 0;
 while(list($type, $text, $linkName, $linkID, $timeSent) = $DB->tabl_row($tabl))
 {
 	if ($type == 'Game')
@@ -63,10 +64,11 @@ while(list($type, $text, $linkName, $linkID, $timeSent) = $DB->tabl_row($tabl))
 	$rssfeed .= "<item>\n";
 	$rssfeed .= "<title>".$linkName."</title>\n";
 	$rssfeed .= "<description>".$text."</description>\n";
-	$rssfeed .= "<guid>".$link."time".$timeSent."</guid>\n";
+	$rssfeed .= "<guid>".$link."time".$timeSent."index".$index."</guid>\n";
 	$rssfeed .= "<link>".$link."</link>\n";
 	$rssfeed .= "<pubDate>".date("D, d M Y H:i:s O", $timeSent)."</pubDate>\n";
 	$rssfeed .= "</item>\n";
+	$index++;
 }
  
 $rssfeed .= "</channel>\n";

--- a/rss.php
+++ b/rss.php
@@ -63,7 +63,8 @@ while(list($type, $text, $linkName, $linkID, $timeSent) = $DB->tabl_row($tabl))
 	$rssfeed .= "    <item>\n";
 	$rssfeed .= "      <title>".$linkName."</title>\n";
 	$rssfeed .= "      <description>".$text."</description>\n";
-	$rssfeed .= "      <guid>".$link."time".$timeSent."</guid>\n";
+	// remove guid entry as it is not unique (timeSent can be duplicate)
+	// $rssfeed .= "      <guid>".$link."time".$timeSent."</guid>\n";
 	$rssfeed .= "      <link>".$link."</link>\n";
 	$rssfeed .= "      <pubDate>".date("D, d M Y H:i:s O", $timeSent)."</pubDate>\n";
 	$rssfeed .= "    </item>\n";


### PR DESCRIPTION
The RSS feed is not valid due to duplicated \<guid\> tags. This happens as the guid tags use the event timestamp.

This means that you cannot subscribe to the feed with an RSS reader as it is an invalid feed.

Here you can see two items from my personal RSS feed with the same GUID, as they are events that happened at the same time. 

```RSS
<item>
<title>AlanBeanium</title>
<description>Game progressed to Builds, Autumn, 1998</description>
<guid>http://vdiplomacy.com//board.php?gameID=54271time1673464802</guid>
<link>http://vdiplomacy.com//board.php?gameID=54271</link>
<pubDate>Wed, 11 Jan 2023 19:20:02 +0000</pubDate>
</item>
<item>
<title>AlanBeanium</title>
<description>Italy has gone into civil disorder.</description>
<guid>http://vdiplomacy.com//board.php?gameID=54271time1673464802</guid>
<link>http://vdiplomacy.com//board.php?gameID=54271</link>
<pubDate>Wed, 11 Jan 2023 19:20:02 +0000</pubDate>
</item>
```

`time1673464802` == `time1673464802`

See [Feed Validator](https://validator.w3.org/feed/check.cgi?url=http%3A%2F%2Fvdiplomacy.com%2Frss.php%3FrssID%3DHLhOvBW0wMvKKM3bSlpxKeMaeaZLKq) to check RSS feed validity

FIX:

- add index to RSS feed generator to provide each \<item\> with an *actual* unique ID.