### PR TITLE
Remove junk PHP syntax from register.php

### DIFF
--- a/locales/English/userRegister.php
+++ b/locales/English/userRegister.php
@@ -34,5 +34,4 @@ defined('IN_CODE') or die('This script can not be run by itself.');
 	}
 	?>"></li>
 <li class="formlistdesc">Your vDiplomacy username.</li>
-	?>">
 </p>


### PR DESCRIPTION
The string `?>">` was in the English locale file for `userRegister.php`, which is an include on `register.php` after email confirmation. This looks like it was just a mistaken partial copy of a line slightly above it, and was just output as a text string to the DOM below the username field. This pull request removes that.

I did look at the Italian locale's PHP file and it didn't appear that the error would appear there, but I did not check this thoroughly.

![2025-03-22_18-49-27](https://github.com/user-attachments/assets/0a37053e-19bd-4fce-b28d-efa3c3a7caca)
![2025-03-22_18-48-47](https://github.com/user-attachments/assets/459987c7-5321-421d-96ea-4cb80a160fd5)
